### PR TITLE
Implement logger function using dart:developer

### DIFF
--- a/bin/server.dart
+++ b/bin/server.dart
@@ -5,6 +5,7 @@ import 'package:args/args.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf/shelf_io.dart' as io;
 import 'package:shelf_server/src/endpoints.dart';
+import 'package:shelf_server/src/logger.dart';
 import 'package:shelf_static/shelf_static.dart';
 
 const String defaultUrl = '127.0.0.1';
@@ -43,7 +44,7 @@ void _handleRequests(int port) {
     // Enable content compression
     server.autoCompress = true;
 
-    print('Serving at http://${server.address.host}:${server.port}');
+    logger('Serving at http://${server.address.host}:${server.port}');
   });
 
 }
@@ -51,21 +52,17 @@ void _handleRequests(int port) {
 /// Handles the logic for most requests
 /// Forward request to service unless to /logs
 Future<shelf.Response> _endpointsHandler(shelf.Request request) async {
-  print('Got request for ${request.url.path}');
+  logger('Got request for ${request.url.path}');
   var finalResponse = new shelf.Response.internalServerError();
 
   for (var url in endpoints.keys) {
     var endpointExp = new RegExp(url);
 
     if (endpointExp.hasMatch(request.url.path)) {
-      print('$url contains ${request.url.path}');
+      logger('$url contains ${request.url.path}');
       finalResponse = new shelf.Response.ok('');
     }
   }
 
   return finalResponse;
-}
-
-void logger(String msg, {bool isError}) {
-
 }

--- a/lib/src/logger.dart
+++ b/lib/src/logger.dart
@@ -1,0 +1,20 @@
+import 'dart:developer' show log;
+
+void logger(String msg, { LogLevel level, Error error, StackTrace stackTrace}) {
+  switch (level) {
+    case LogLevel.error:
+      log(msg, level: 1000, error: error, stackTrace: stackTrace);
+      break;
+    case LogLevel.warn:
+      log(msg, level: 500);
+      break;
+    case LogLevel.info:
+      log(msg);
+  }
+}
+
+enum LogLevel {
+  info,
+  warn,
+  error
+}


### PR DESCRIPTION
I created the logger and moved it to it's own file under `lib/`

I made `info` the default level since there were no current instances of error handling.

I used `dart:developer`'s `log` method instead of `dart:core`'s `print` method because there are lint rules against using print in production and I figured `log` was provided for a reason.