### PR TITLE
Update README with directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # shelf_server
 
+A ready to use server for any web content.
+
 ## Getting Started
 
 ### Dart
@@ -7,18 +9,30 @@
 * Add the Dart SDK to your path.
 * From a new command window, type `dart --version` to verify that Dart is now available.
 
-### dartium
-* [Install](https://www.dartlang.org/install/archive) the matching version of `dartium` (a version of Chrome with 
-the Dart virtual machine embedded that is useful for testing).
-* Change the name of the executable from `chromium` to `dartium`.
-* Add the `dartium` executable to your path.
-* From a new command window, type `dartium --version` to verify that Dartium is now available.
-
 ### Dart Plugin for your IDE
 * If you are using IntelliJ, [install and configure the Dart plugin](https://www.dartlang.org/tools/jetbrains-plugin).
 
 ### Setting up Dart on your IDE
-* Setup the Dart SDK and Dartium by going in your IDE's settings and add the Dart SDK
+* Set up the Dart SDK and Dartium by going in your IDE's settings and add the Dart SDK
 * Note: For HomeBrew Mac users the Dart SDK and Dartium locations are:
   * SDK directory: `HOMEBREW_INSTALL/dart/1.24.2/libexec`
-  * Dartium: `HOMEBREW_INSTALL/dart/1.24.2/Chromium.app`
+
+## Using shelf_server
+
+To use shelf_server from anywhere, use Dart to make it globally available.
+
+From the root directory of this project run:
+`dart pub global activate --source path . --executable ./bin/server.dart`
+
+Then execute the app using `dart pub global run`:
+
+`dart pub global run shelf_server`
+
+## Options
+
+Currently, there's only one option:
+
+**--port | -p**: Defines what port number to use when serving the web content.
+`dart pub global run shelf_server --port 8082`
+
+By default, shelf_server uses 127.0.0.1 (localhost) and port 8082

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A ready to use server for any web content.
 ## Getting Started
 
 ### Dart
-* [Install Dart](https://www.dartlang.org/install/archive)  >= 1.24.2 
+* [Install Dart](https://www.dartlang.org/install/archive)  >= 2.14.0
 * Add the Dart SDK to your path.
 * From a new command window, type `dart --version` to verify that Dart is now available.
 
@@ -15,7 +15,7 @@ A ready to use server for any web content.
 ### Setting up Dart on your IDE
 * Set up the Dart SDK and Dartium by going in your IDE's settings and add the Dart SDK
 * Note: For HomeBrew Mac users the Dart SDK and Dartium locations are:
-  * SDK directory: `HOMEBREW_INSTALL/dart/1.24.2/libexec`
+  * SDK directory: `HOMEBREW_INSTALL/dart/2.14.0/libexec`
 
 ## Using shelf_server
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 homepage: https://github.com/mcmahonjohn/shelf_server
 
 environment:
-  sdk: '>=1.24.2 <3.0.0'
+  sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
   args: ^2.0.0


### PR DESCRIPTION
Closes #7

Update README based on direction in #7

I did have a question about whether the app should list 1.24.2 as the minimum version of Dart accepted.

Looking at the lock file it seems the project is suited for 2.14.0 and above. But I left it as 1.24.2 and I can correct it.